### PR TITLE
Updates and Bug Fixes

### DIFF
--- a/alertwise/requirements/base.txt
+++ b/alertwise/requirements/base.txt
@@ -3,7 +3,7 @@ djangorestframework-xml
 python-magic
 shapely>=2.0.1
 wagtail-icon-chooser>=0.3.0
-adm-boundary-manager>=0.2.4
+adm-boundary-manager>=0.2.5
 wagtail-humanitarian-icons>=2.0.0
 wagtail-modelchooser>=4.0.1
 paho-mqtt

--- a/alertwise/src/alertwise/cap/templates/cap/alert_list.html
+++ b/alertwise/src/alertwise/cap/templates/cap/alert_list.html
@@ -25,31 +25,30 @@
                         {% endif %}
                     </div>
                 {% endif %}
-
                 <div class="columns is-multiline is-mobile">
                     <div class="column is-three-fifths-desktop is-full-touch alerts-list">
-                        <div class="alerts-group">
-                            <div class="group-title">
-                                {% translate "Active Alerts" %}
-                            </div>
-
-                            {% if alerts_by_expiry.active_alerts %}
-                                {% for alert_info in alerts_by_expiry.active_alerts %}
-                                    {% include "cap/include_alert_list_item.html" with alert_info=alert_info %}
-                                {% endfor %}
-                            {% else %}
-                                <div class="empty-alerts-state">
-                                    <div class="empty-alerts-icon">
-                                        {% svg_icon name="alert" %}
-                                    </div>
-                                    <div>
-                                        {% translate "No active alerts currently" %}
-                                    </div>
+                        {% if alerts_by_expiry.active_alerts or pagination.number == 1 %}
+                            <div class="alerts-group">
+                                <div class="group-title">
+                                    {% translate "Active Alerts" %}
                                 </div>
-                            {% endif %}
-                            {% include 'cap/pagination_include.html' with items=pagination %}
-                        </div>
 
+                                {% if alerts_by_expiry.active_alerts %}
+                                    {% for alert_info in alerts_by_expiry.active_alerts %}
+                                        {% include "cap/include_alert_list_item.html" with alert_info=alert_info %}
+                                    {% endfor %}
+                                {% else %}
+                                    <div class="empty-alerts-state">
+                                        <div class="empty-alerts-icon">
+                                            {% svg_icon name="alert" %}
+                                        </div>
+                                        <div>
+                                            {% translate "No active alerts currently" %}
+                                        </div>
+                                    </div>
+                                {% endif %}
+                            </div>
+                        {% endif %}
                         {% if  alerts_by_expiry.past_alerts %}
                             <div class="alerts-group">
                                 <div class="group-title">
@@ -60,9 +59,9 @@
                                 {% endfor %}
                             </div>
                         {% endif %}
+
+                        {% include 'cap/pagination_include.html' with items=pagination %}
                     </div>
-
-
                     <div class="column is-offset-1-desktop is-one-fifth-widescreen is-full-touch is-hidden-touch">
                         {% if filters.severity %}
                             <div class="alert-category-filter">
@@ -123,7 +122,6 @@
                 </div>
             </div>
         </section>
-
     </main>
 
 {% endblock %}

--- a/alertwise/src/alertwise/cap/wagtail_hooks.py
+++ b/alertwise/src/alertwise/cap/wagtail_hooks.py
@@ -309,9 +309,22 @@ def copy_cap_alert_page(request, page):
             request.POST or None, user=request.user, page=page, can_publish=can_publish
         )
         
-        # Remove the publish_copies and alias fields from the form
-        form.fields.pop("publish_copies")
-        form.fields.pop("alias")
+        copy_form_fields_to_exclude = [
+            "publish_copies",
+            "alias",
+        ]
+        
+        for field in copy_form_fields_to_exclude:
+            if form.fields.get(field):
+                form.fields.pop(field)
+        
+        alert_page_fields_to_exclude = [
+            "alert_area_map_image",
+            "alert_pdf_preview",
+            "expires",
+            "search_image",
+            "search_description",
+        ]
         
         # Check if user is submitting
         if request.method == "POST":
@@ -336,7 +349,9 @@ def copy_cap_alert_page(request, page):
                     keep_live=False,
                     copy_revisions=False,
                     user=request.user,
+                    exclude_fields=alert_page_fields_to_exclude,
                 )
+                
                 new_page = action.execute()
                 
                 messages.success(

--- a/alertwise/src/alertwise/config/templates/wagtailadmin/shared/field_as_li.html
+++ b/alertwise/src/alertwise/config/templates/wagtailadmin/shared/field_as_li.html
@@ -1,2 +1,0 @@
-{% load wagtailadmin_tags %}
-{% formattedfieldfromcontext %}

--- a/alertwise/src/alertwise/version.py
+++ b/alertwise/src/alertwise/version.py
@@ -1,6 +1,6 @@
 # major.minor.patch.release.number
 # release must be one of alpha, beta, rc, or final
-VERSION = (1, 0, 3, "final", 0)
+VERSION = (1, 0, 4, "final", 0)
 
 
 def get_semver_version(version):


### PR DESCRIPTION
- Update CAP listing to show page numbers at bottom
- Exclude some fields when copying alerts
- Update adm-boundary-manager to 0.2.5
- Remove `field_as_li.html` that is deprecated in Wagtail > 6