### PR TITLE
Update wagtail-icon-chooser

### DIFF
--- a/alertwise/requirements/base.txt
+++ b/alertwise/requirements/base.txt
@@ -2,7 +2,7 @@ wagtail>=6.0
 djangorestframework-xml
 python-magic
 shapely>=2.0.1
-wagtail-icon-chooser>=0.3.0
+wagtail-icon-chooser>=0.3.1
 adm-boundary-manager>=0.2.5
 wagtail-humanitarian-icons>=2.0.0
 wagtail-modelchooser>=4.0.1

--- a/alertwise/src/alertwise/version.py
+++ b/alertwise/src/alertwise/version.py
@@ -1,6 +1,6 @@
 # major.minor.patch.release.number
 # release must be one of alpha, beta, rc, or final
-VERSION = (1, 0, 4, "final", 0)
+VERSION = (1, 0, 5, "final", 0)
 
 
 def get_semver_version(version):


### PR DESCRIPTION
- This PR updates wagtail-icon-chooser to version >=0.3.1. The update fixes the IconChooserBlock issue, which prevented selecting an icon or closing the Icon chooser modal