### PR TITLE
Fix dates translation on alert detail template

### DIFF
--- a/alertwise/src/alertwise/cap/templates/cap/alert_detail.html
+++ b/alertwise/src/alertwise/cap/templates/cap/alert_detail.html
@@ -389,7 +389,7 @@
                                                                             {% translate "Issued" %}
                                                                         </span>
                                                                         <span>
-                                                                            {{ page.sent }}
+                                                                            {{ page.sent|date:"D d M Y H:i"  }}
                                                                         </span>
                                                                     </div>
                                                                 </li>
@@ -401,9 +401,9 @@
                                                                         </span>
                                                                         <span>
                                                                             {% if  item.value.effective %}
-                                                                                {{ item.value.effective }}
+                                                                                {{ item.value.effective|date:"D d M Y H:i" }}
                                                                             {% else %}
-                                                                                {{ page.sent }}
+                                                                                {{ page.sent|date:"D d M Y H:i" }}
                                                                             {% endif %}
                                                                         </span>
                                                                     </div>
@@ -415,7 +415,8 @@
                                                                             <span class="time-type">
                                                                                 {% translate "Onset" %}:
                                                                             </span>
-                                                                            <span>{{ item.value.onset }}</span></div>
+                                                                            <span>{{ item.value.onset|date:"D d M Y H:i" }}</span>
+                                                                        </div>
                                                                     </li>
                                                                 {% endif %}
                                                                 <li class="warning-timeline__item">
@@ -424,7 +425,7 @@
                                                                         <span class="time-type">
                                                                             {% translate "Expires" %}:
                                                                         </span>
-                                                                        <span>{{ item.value.expires }}</span>
+                                                                        <span>{{ item.value.expires|date:"D d M Y H:i" }}</span>
                                                                     </div>
                                                                 </li>
                                                             </ul>

--- a/alertwise/src/alertwise/version.py
+++ b/alertwise/src/alertwise/version.py
@@ -1,6 +1,6 @@
 # major.minor.patch.release.number
 # release must be one of alpha, beta, rc, or final
-VERSION = (1, 1, 1, "final", 0)
+VERSION = (1, 1, 2, "final", 0)
 
 
 def get_semver_version(version):


### PR DESCRIPTION
- This PR fixes alert detail default template to use date filters, that ensure correct dates (months) translations